### PR TITLE
security: bump Newtonsoft.Json to 13.0.1

### DIFF
--- a/YtManagement.Common/YtManagement.Common.csproj
+++ b/YtManagement.Common/YtManagement.Common.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
 </Project>

--- a/YtManagement.Monitor/YtManagement.Monitor.csproj
+++ b/YtManagement.Monitor/YtManagement.Monitor.csproj
@@ -32,8 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="ObjectListView, Version=2.9.1.1072, Culture=neutral, PublicKeyToken=b1c5bf581481bcd4, processorArchitecture=MSIL">
       <HintPath>..\packages\ObjectListView.Official.2.9.1\lib\net20\ObjectListView.dll</HintPath>

--- a/YtManagement.Monitor/packages.config
+++ b/YtManagement.Monitor/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net461" />
   <package id="ObjectListView.Official" version="2.9.1" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
## Summary
- bump Newtonsoft.Json from 11.0.2 to 13.0.1
- updates PackageReference + packages.config + csproj hint path/reference version

## Security
- addresses CVE-2024-21907 reported by Dependabot

Closes #7
